### PR TITLE
Add serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0 OR MIT"
 edition = "2018"
 readme = "README.md"
 
+[dependencies]
+serde = { version = "1.0.205", optional = true, features = ["derive"] }
+
 [features]
 default = ["std"]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-serde = { version = "1.0.205", optional = true, features = ["derive"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,13 @@ mod std_ext;
 #[cfg(feature = "std")]
 pub use self::std_ext::*;
 
+#[cfg(feature="serde")]
+#[macro_use]
+extern crate serde;
+
 /// Recognized image types
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Type {
     /// Gif 87a and 89a Files
     Gif,


### PR DESCRIPTION
I had a use case for de/serialization the imghdr::Type enum. Due to the orphan rule I wasn't able to directly within my crate, so I added the implementation within imghdr and added it as an optional feature.